### PR TITLE
Lock workstation instead of logging off

### DIFF
--- a/LoginForm.cs
+++ b/LoginForm.cs
@@ -83,7 +83,7 @@ namespace ClockEnforcer
             authService = new AuthService(apiKey);
             punchService = new PunchService(authService);
 
-            statusTextBox.Text = "Please log in. You have 2 minutes to clock in before forced logout.";
+            statusTextBox.Text = "Please log in. You have 2 minutes to clock in before forced lock.";
 
             this.Load += LoginForm_Load;
             SetupTrayIcon();
@@ -161,8 +161,9 @@ namespace ClockEnforcer
         private void LoginTimer_Tick(object sender, EventArgs e)
         {
             loginTimer.Stop();
-            MessageBox.Show("You did not clock in within 2 minutes. Logging off.");
+            MessageBox.Show("You did not clock in within 2 minutes. Locking workstation.");
             new PCLoginEnforcer().ForceUserLogOff();
+            loginTimer.Start();
         }
 
         private async void OvertimeCheckTimer_Tick(object sender, EventArgs e)

--- a/PCLoginEnforcer.cs
+++ b/PCLoginEnforcer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 using ClockEnforcer.Services;
@@ -79,7 +80,21 @@ namespace ClockEnforcer
             }
 
             await Task.Delay(10000);
-            System.Diagnostics.Process.Start("shutdown", "/l");
+            try
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = "rundll32.exe",
+                    Arguments = "user32.dll,LockWorkStation",
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                });
+            }
+            catch (Exception ex)
+            {
+                File.AppendAllText(debugLogPath,
+                    $"{DateTime.Now}: ERROR locking workstation: {ex.Message}{Environment.NewLine}");
+            }
         }
 
         private async Task ForcePunchOutAsync(string user)

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Status message box
 Handles:
 Authentication via AuthService
 Auto clock‑in after login, delaying 1s
-2‑minute auto‑logout guard if no punch-in
-5‑hour auto‑logout guard if no punch-out
+2‑minute auto-lock guard if no punch-in
+5‑hour auto-lock guard if no punch-out
 Punch action (clock‑in/out) via PunchService
 Launching the OvertimeRequestForm
 
@@ -42,7 +42,7 @@ Provides IsUserLockedOut to enforce lockout periods based on last clock‑out ti
 
 -PCLoginEnforcer.cs
 Called at process startup (via Program.cs) and on explicit calls.
-Uses LogService.IsUserLockedOut to decide whether to immediately log off the Windows session.
+Uses LogService.IsUserLockedOut to decide whether to immediately lock the Windows session.
 
 -SessionEnforcementManager.cs
 Centralizes all session timers:


### PR DESCRIPTION
## Summary
- update the login enforcement flow to lock the workstation rather than logging the user out
- refresh on-screen messaging and timer behavior so users receive a new 2-minute window after unlocking
- document the auto-lock behavior in the README

## Testing
- `dotnet build ClockEnforcer.sln` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fbd15078388328b2de97d6d0f52cff