### PR TITLE
Ensure diagnostic logs write to shared AppData directory

### DIFF
--- a/AppPaths.cs
+++ b/AppPaths.cs
@@ -1,0 +1,22 @@
+using System;
+using System.IO;
+
+namespace ClockEnforcer
+{
+    internal static class AppPaths
+    {
+        public static string BaseFolder { get; } = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+            "ClockEnforcer");
+
+        static AppPaths()
+        {
+            Directory.CreateDirectory(BaseFolder);
+        }
+
+        public static string GetPath(string fileName)
+        {
+            return Path.Combine(BaseFolder, fileName);
+        }
+    }
+}

--- a/LogService.cs
+++ b/LogService.cs
@@ -1,25 +1,18 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using ClockEnforcer;
 
 namespace ClockEnforcer.Services
 {
     public class LogService
     {
-        private static readonly string BaseFolder =
-            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "ClockEnforcer");
+        private static readonly string LoginLogFilePath = AppPaths.GetPath("user_logins.txt");
 
-        private static readonly string LoginLogFilePath =
-            Path.Combine(BaseFolder, "user_logins.txt");
-
-        private static readonly string CredentialsFilePath =
-            Path.Combine(BaseFolder, "user_credentials.txt");
+        private static readonly string CredentialsFilePath = AppPaths.GetPath("user_credentials.txt");
 
         static LogService()
         {
-            if (!Directory.Exists(BaseFolder))
-                Directory.CreateDirectory(BaseFolder);
-
             if (!File.Exists(LoginLogFilePath))
                 File.Create(LoginLogFilePath).Close();
 
@@ -44,7 +37,7 @@ namespace ClockEnforcer.Services
             if (!alreadyLoggedInToday && password != null)
             {
                 File.AppendAllText(CredentialsFilePath, $"{systemUsername},{timestamp},{clockinUsername},{password}{Environment.NewLine}");
-                File.AppendAllText(Path.Combine(BaseFolder, "overtime_debug_log.txt"), $"{timestamp}: Credenciales guardadas de {systemUsername} como {clockinUsername}{Environment.NewLine}");
+                File.AppendAllText(AppPaths.GetPath("overtime_debug_log.txt"), $"{timestamp}: Credenciales guardadas de {systemUsername} como {clockinUsername}{Environment.NewLine}");
             }
         }
 

--- a/LoginForm.cs
+++ b/LoginForm.cs
@@ -17,6 +17,8 @@ namespace ClockEnforcer
         private readonly AuthService authService;
         private readonly PunchService punchService;
         private readonly LogService logService = new LogService();
+        private readonly string overtimeLogPath = AppPaths.GetPath("overtime_debug_log.txt");
+        private readonly string errorLogPath = AppPaths.GetPath("error_log.txt");
         private bool loginAlreadyLogged = false;
 
         private System.Windows.Forms.Timer loginTimer;
@@ -179,7 +181,7 @@ namespace ClockEnforcer
                 var response = await client.GetAsync(url);
                 string json = await response.Content.ReadAsStringAsync();
 
-                File.AppendAllText("overtime_debug_log.txt", $"{DateTime.Now}: Raw JSON: {json}{Environment.NewLine}");
+                File.AppendAllText(overtimeLogPath, $"{DateTime.Now}: Raw JSON: {json}{Environment.NewLine}");
 
                 if (!response.IsSuccessStatusCode) return;
 
@@ -187,12 +189,12 @@ namespace ClockEnforcer
                 if (result?.data?.accepted == true)
                 {
                     overtimeAdded = true;
-                    File.AppendAllText("overtime_debug_log.txt", $"{DateTime.Now}: Overtime approved: {result.data.hours}h{Environment.NewLine}");
+                    File.AppendAllText(overtimeLogPath, $"{DateTime.Now}: Overtime approved: {result.data.hours}h{Environment.NewLine}");
                 }
             }
             catch (Exception ex)
             {
-                File.AppendAllText("overtime_debug_log.txt", $"{DateTime.Now}: ERROR: {ex.Message}{Environment.NewLine}");
+                File.AppendAllText(overtimeLogPath, $"{DateTime.Now}: ERROR: {ex.Message}{Environment.NewLine}");
             }
         }
 
@@ -225,7 +227,7 @@ namespace ClockEnforcer
             catch (Exception ex)
             {
                 statusTextBox.Text = "An error occurred during login. Please try again.";
-                File.AppendAllText("error_log.txt", $"{DateTime.Now}: {ex}{Environment.NewLine}");
+                File.AppendAllText(errorLogPath, $"{DateTime.Now}: {ex}{Environment.NewLine}");
             }
             finally
             {


### PR DESCRIPTION
## Summary
- add an AppPaths helper to centralize the ProgramData directory used by the app
- update LogService and LoginForm to route all log files through the shared application data folder

## Testing
- dotnet build *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fbd7f03fa48328bc9052c8f17f65f5