### PR TITLE
Embed SAASHR API key

### DIFF
--- a/PCLoginEnforcer.cs
+++ b/PCLoginEnforcer.cs
@@ -12,15 +12,11 @@ namespace ClockEnforcer
         private readonly PunchService punchService;
         private readonly LogService logService = new LogService();
 
+        private const string ApiKey = "iibh7b86dlces64stxqwm15n65kvkhf3";
+
         public PCLoginEnforcer()
         {
-            string apiKey = Environment.GetEnvironmentVariable(
-                "SAASHR_API_KEY",
-                EnvironmentVariableTarget.Machine);
-            if (string.IsNullOrWhiteSpace(apiKey))
-                throw new InvalidOperationException("Set SAASHR_API_KEY in the Environment Variables");
-
-            authService = new AuthService(apiKey);
+            authService = new AuthService(ApiKey);
             punchService = new PunchService(authService);
         }
 


### PR DESCRIPTION
## Summary
- embed the SAASHR API key directly in `PCLoginEnforcer`
- remove the environment variable lookup for the API key

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6903e4eb50d4832889fd03aecdf26bf7