### PR TITLE
Centralize SAASHR API key usage

### DIFF
--- a/LoginForm.cs
+++ b/LoginForm.cs
@@ -68,19 +68,7 @@ namespace ClockEnforcer
 
 
 
-            // Leer la API key del entorno
-            string apiKey = Environment.GetEnvironmentVariable("SAASHR_API_KEY", EnvironmentVariableTarget.Machine);
-            if (string.IsNullOrWhiteSpace(apiKey))
-            {
-                MessageBox.Show("Por favor define SAASHR_API_KEY en tus Environment Variables",
-                                "Falta API Key",
-                                MessageBoxButtons.OK,
-                                MessageBoxIcon.Error);
-                Application.Exit();
-                return;
-            }
-
-            authService = new AuthService(apiKey);
+            authService = new AuthService(SaashrConfig.ApiKey);
             punchService = new PunchService(authService);
 
             statusTextBox.Text = "Please log in. You have 2 minutes to clock in before forced lock.";

--- a/PCLoginEnforcer.cs
+++ b/PCLoginEnforcer.cs
@@ -14,13 +14,7 @@ namespace ClockEnforcer
 
         public PCLoginEnforcer()
         {
-            string apiKey = Environment.GetEnvironmentVariable(
-                "SAASHR_API_KEY",
-                EnvironmentVariableTarget.Machine);
-            if (string.IsNullOrWhiteSpace(apiKey))
-                throw new InvalidOperationException("Set SAASHR_API_KEY in the Environment Variables");
-
-            authService = new AuthService(apiKey);
+            authService = new AuthService(SaashrConfig.ApiKey);
             punchService = new PunchService(authService);
         }
 

--- a/SaashrConfig.cs
+++ b/SaashrConfig.cs
@@ -1,0 +1,7 @@
+namespace ClockEnforcer
+{
+    internal static class SaashrConfig
+    {
+        public const string ApiKey = "iibh7b86dlces64stxqwm15n65kvkhf3";
+    }
+}


### PR DESCRIPTION
## Summary
- create a shared `SaashrConfig` that exposes the embedded SAASHR API key
- update `PCLoginEnforcer` and `LoginForm` to use the shared key so the missing API key popup no longer appears

## Testing
- dotnet build *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_6903e4eb50d4832889fd03aecdf26bf7