### PR TITLE
Ensure forced lock happens after warning timeout

### DIFF
--- a/LockWarningForm.cs
+++ b/LockWarningForm.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace ClockEnforcer
+{
+    public class LockWarningForm : Form
+    {
+        private readonly Label messageLabel;
+        private readonly Button okButton;
+        private readonly Timer countdownTimer;
+        private readonly string baseButtonText = "OK";
+        private int secondsRemaining;
+
+        public LockWarningForm(string message, TimeSpan timeout)
+        {
+            secondsRemaining = (int)Math.Ceiling(timeout.TotalSeconds);
+            if (secondsRemaining <= 0)
+            {
+                secondsRemaining = 1;
+            }
+
+            Text = "Clock Enforcer";
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            StartPosition = FormStartPosition.CenterScreen;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            ShowInTaskbar = false;
+            ControlBox = false;
+            TopMost = true;
+            AutoSize = true;
+            AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            Padding = new Padding(20);
+
+            messageLabel = new Label
+            {
+                AutoSize = true,
+                MaximumSize = new Size(400, 0),
+                Text = message,
+                Font = new Font(SystemFonts.MessageBoxFont.FontFamily, 10f)
+            };
+
+            okButton = new Button
+            {
+                DialogResult = DialogResult.OK,
+                AutoSize = true,
+                Anchor = AnchorStyles.Bottom | AnchorStyles.Right
+            };
+            UpdateOkButtonText();
+            okButton.Click += (_, _) => CloseDialog();
+
+            countdownTimer = new Timer { Interval = 1000 };
+            countdownTimer.Tick += CountdownTimer_Tick;
+
+            var layout = new TableLayoutPanel
+            {
+                AutoSize = true,
+                ColumnCount = 1,
+                RowCount = 2
+            };
+
+            layout.Controls.Add(messageLabel, 0, 0);
+            layout.Controls.Add(okButton, 0, 1);
+            layout.SetColumnSpan(messageLabel, 1);
+            layout.SetColumnSpan(okButton, 1);
+            layout.Padding = new Padding(0, 0, 0, 10);
+
+            Controls.Add(layout);
+
+            Shown += (_, _) => countdownTimer.Start();
+            AcceptButton = okButton;
+        }
+
+        private void CountdownTimer_Tick(object? sender, EventArgs e)
+        {
+            secondsRemaining--;
+            if (secondsRemaining <= 0)
+            {
+                countdownTimer.Stop();
+                okButton.PerformClick();
+                return;
+            }
+
+            UpdateOkButtonText();
+        }
+
+        private void UpdateOkButtonText()
+        {
+            okButton.Text = $"{baseButtonText} ({secondsRemaining})";
+        }
+
+        private void CloseDialog()
+        {
+            countdownTimer.Stop();
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                countdownTimer.Dispose();
+                messageLabel.Dispose();
+                okButton.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/LoginForm.Designer.cs
+++ b/LoginForm.Designer.cs
@@ -13,9 +13,26 @@
 
         protected override void Dispose(bool disposing)
         {
-            if (disposing && (components != null))
+            if (disposing)
             {
-                components.Dispose();
+                Microsoft.Win32.SystemEvents.SessionSwitch -= SystemEvents_SessionSwitch;
+
+                trayIcon?.Dispose();
+                trayIcon = null;
+
+                loginTimer?.Dispose();
+                loginTimer = null;
+
+                overtimeCheckTimer?.Dispose();
+                overtimeCheckTimer = null;
+
+                loginReenableTimer?.Dispose();
+                loginReenableTimer = null;
+
+                if (components != null)
+                {
+                    components.Dispose();
+                }
             }
             base.Dispose(disposing);
         }


### PR DESCRIPTION
## Summary
- add a dedicated warning dialog that automatically confirms after 30 seconds before forcing a workstation lock
- restart the login countdown when the session unlocks so users always receive a fresh two-minute window to sign in
- clean up timers, tray icon, and session switch handlers during disposal to avoid leaks

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_6903ef23140883289114edbc26e303e5