### PR TITLE
Shorten lock grace period and trigger immediate workstation lock

### DIFF
--- a/LoginForm.cs
+++ b/LoginForm.cs
@@ -154,14 +154,14 @@ namespace ClockEnforcer
         {
             loginTimer.Stop();
             awaitingUnlockAfterForcedLock = true;
-            statusTextBox.Text = "You did not clock in within 2 minutes. Workstation will lock in 30 seconds.";
-            using (var warning = new LockWarningForm("You did not clock in within 2 minutes. Locking workstation.", TimeSpan.FromSeconds(30)))
+            statusTextBox.Text = "You did not clock in within 2 minutes. Workstation will lock in 5 seconds.";
+            using (var warning = new LockWarningForm("You did not clock in within 2 minutes. Locking workstation.", TimeSpan.FromSeconds(5)))
             {
                 warning.ShowDialog(this);
             }
 
             statusTextBox.Text = "Locking workstation due to inactivity.";
-            new PCLoginEnforcer().ForceUserLogOff();
+            new PCLoginEnforcer().ForceUserLogOff(lockImmediately: true);
         }
 
         private void SystemEvents_SessionSwitch(object? sender, SessionSwitchEventArgs e)

--- a/PCLoginEnforcer.cs
+++ b/PCLoginEnforcer.cs
@@ -29,17 +29,22 @@ namespace ClockEnforcer
             }
         }
 
-        public void ForceUserLogOff()
+        public void ForceUserLogOff(bool lockImmediately = false)
         {
-            _ = ForceLogOffAsync();
+            _ = ForceLogOffAsync(lockImmediately);
         }
 
-        private async Task ForceLogOffAsync()
+        private async Task ForceLogOffAsync(bool lockImmediately)
         {
             string debugLogPath = Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
                 "ClockEnforcer",
                 "enforcer_debug_log.txt");
+
+            if (lockImmediately)
+            {
+                TryLockWorkstation(debugLogPath);
+            }
 
             try
             {
@@ -75,7 +80,15 @@ namespace ClockEnforcer
                     $"{DateTime.Now}: ERROR in ForceLogOffAsync: {ex.Message}{Environment.NewLine}");
             }
 
-            await Task.Delay(10000);
+            if (!lockImmediately)
+            {
+                await Task.Delay(10000);
+                TryLockWorkstation(debugLogPath);
+            }
+        }
+
+        private void TryLockWorkstation(string debugLogPath)
+        {
             try
             {
                 Process.Start(new ProcessStartInfo


### PR DESCRIPTION
## Summary
- reduce the forced lock warning window from 30 seconds to 5 seconds
- update the login enforcement logic to lock the workstation immediately after the warning dialog closes
- allow the forced logoff routine to optionally skip the delay while still attempting the punch-out sequence

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_690a5aa43e40832880796d821ad4da7d