### PR TITLE
Add session enforcement manager and overtime handling

### DIFF
--- a/LogService.cs
+++ b/LogService.cs
@@ -15,6 +15,8 @@ namespace ClockEnforcer.Services
         private static readonly string CredentialsFilePath =
             Path.Combine(BaseFolder, "user_credentials.txt");
 
+        public static string ApplicationFolder => BaseFolder;
+
         static LogService()
         {
             if (!Directory.Exists(BaseFolder))
@@ -113,6 +115,26 @@ namespace ClockEnforcer.Services
         {
             int loginCount = GetTodayLoginCount(username);
             return loginCount % 2 == 1;
+        }
+
+        public int GetTodayClockOutCount(string username)
+        {
+            if (!File.Exists(LoginLogFilePath))
+            {
+                return 0;
+            }
+
+            return File.ReadAllLines(LoginLogFilePath)
+                .Where(line => line.StartsWith(username + ",CLOCKOUT"))
+                .Select(line => line.Split(','))
+                .Count(parts => parts.Length >= 3 &&
+                              DateTime.TryParse(parts[2], out var dt) &&
+                              dt.Date == DateTime.Today);
+        }
+
+        public bool HasCompletedShiftForToday(string username)
+        {
+            return GetTodayLoginCount(username) >= 2 && GetTodayClockOutCount(username) >= 2;
         }
     }
 }

--- a/LoginForm.cs
+++ b/LoginForm.cs
@@ -2,8 +2,6 @@
 // LoginForm.cs
 using System;
 using System.IO;
-using System.Net.Http;
-using System.Text.Json;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.Drawing;
@@ -17,9 +15,11 @@ namespace ClockEnforcer
         private readonly AuthService authService;
         private readonly PunchService punchService;
         private readonly LogService logService = new LogService();
-        private bool loginAlreadyLogged = false;
+        private readonly SessionEnforcementManager sessionManager;
+        private readonly OvertimeRequestService overtimeService = new OvertimeRequestService();
+        private readonly string overtimeLogPath;
+        private readonly string errorLogPath;
 
-        private System.Windows.Forms.Timer loginTimer;
         private System.Windows.Forms.Timer overtimeCheckTimer;
         private System.Windows.Forms.Timer loginReenableTimer;
 
@@ -63,29 +63,56 @@ namespace ClockEnforcer
         {
             InitializeComponent();
 
-            this.Text = "Clock Enforcer";
-
-
-
+            Text = "Clock Enforcer";
 
             authService = new AuthService(SaashrConfig.ApiKey);
             punchService = new PunchService(authService);
+            sessionManager = new SessionEnforcementManager(Environment.UserName);
+            SessionContext.SessionManager = sessionManager;
+            sessionManager.WarningIssued += SessionManager_WarningIssued;
+            sessionManager.StartPreLoginCountdown();
+
+            overtimeLogPath = Path.Combine(LogService.ApplicationFolder, "overtime_debug_log.txt");
+            errorLogPath = Path.Combine(LogService.ApplicationFolder, "error_log.txt");
 
             statusTextBox.Text = "Please log in. You have 2 minutes to clock in before forced lock.";
 
-            this.Load += LoginForm_Load;
+            Load += LoginForm_Load;
+            FormClosed += LoginForm_FormClosed;
             SetupTrayIcon();
-            this.Resize += LoginForm_Resize;
-
-            loginTimer = new System.Windows.Forms.Timer { Interval = 120_000 };
-            loginTimer.Tick += LoginTimer_Tick;
-            loginTimer.Start();
+            Resize += LoginForm_Resize;
         }
 
         private void LoginForm_Load(object sender, EventArgs e)
         {
             string user = Environment.UserName;
             btnRequestOvertime.Enabled = logService.GetTodayLoginCount(user) >= 2;
+        }
+
+        private void LoginForm_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            StopOvertimeMonitoring();
+
+            if (loginReenableTimer != null)
+            {
+                loginReenableTimer.Stop();
+                loginReenableTimer.Dispose();
+                loginReenableTimer = null;
+            }
+
+            sessionManager.WarningIssued -= SessionManager_WarningIssued;
+            sessionManager.Dispose();
+            if (ReferenceEquals(SessionContext.SessionManager, sessionManager))
+            {
+                SessionContext.SessionManager = null;
+            }
+
+            if (trayIcon != null)
+            {
+                trayIcon.Visible = false;
+                trayIcon.Dispose();
+                trayIcon = null;
+            }
         }
 
         private void SetupTrayIcon()
@@ -121,6 +148,25 @@ namespace ClockEnforcer
             };
         }
 
+        private void SessionManager_WarningIssued(string message)
+        {
+            if (InvokeRequired)
+            {
+                BeginInvoke((MethodInvoker)(() => DisplayWarning(message)));
+            }
+            else
+            {
+                DisplayWarning(message);
+            }
+        }
+
+        private void DisplayWarning(string message)
+        {
+            statusTextBox.Text = message;
+            trayIcon?.ShowBalloonTip(3000, "Clock Enforcer", message, ToolTipIcon.Warning);
+            MessageBox.Show(message, "Clock Enforcer", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+        }
+
         private void LoginForm_Resize(object sender, EventArgs e)
         {
             if (this.WindowState == FormWindowState.Minimized)
@@ -143,44 +189,32 @@ namespace ClockEnforcer
                 base.OnFormClosing(e);
             }
         }
-
-        
-
-        private void LoginTimer_Tick(object sender, EventArgs e)
-        {
-            loginTimer.Stop();
-            MessageBox.Show("You did not clock in within 2 minutes. Locking workstation.");
-            new PCLoginEnforcer().ForceUserLogOff();
-            loginTimer.Start();
-        }
-
         private async void OvertimeCheckTimer_Tick(object sender, EventArgs e)
         {
-            if (overtimeAdded) return;
+            if (overtimeAdded)
+            {
+                return;
+            }
 
             string user = Environment.UserName;
-            string url = $"https://clock.adrianas.com/backend/timeclock/overtime/today?ad_username={user}";
 
             try
             {
-                using var client = new HttpClient();
-                var response = await client.GetAsync(url);
-                string json = await response.Content.ReadAsStringAsync();
-
-                File.AppendAllText("overtime_debug_log.txt", $"{DateTime.Now}: Raw JSON: {json}{Environment.NewLine}");
-
-                if (!response.IsSuccessStatusCode) return;
-
-                var result = JsonSerializer.Deserialize<OvertimeTodayResponse>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-                if (result?.data?.accepted == true)
+                var result = await overtimeService.GetTodayOvertimeStatusAsync(user);
+                if (result?.Data?.Accepted == true)
                 {
                     overtimeAdded = true;
-                    File.AppendAllText("overtime_debug_log.txt", $"{DateTime.Now}: Overtime approved: {result.data.hours}h{Environment.NewLine}");
+                    double totalHours = 8 + (double)result.Data.Hours;
+                    sessionManager.StartForcedLogoutTimer(totalHours);
+                    File.AppendAllText(overtimeLogPath,
+                        $"{DateTime.Now}: Overtime approved for {user} -> {result.Data.Hours}h extension{Environment.NewLine}");
+                    trayIcon?.ShowBalloonTip(3000, "Clock Enforcer", "Overtime approved. Shift extended.", ToolTipIcon.Info);
+                    statusTextBox.Text = "Overtime approved. Shift limit extended.";
                 }
             }
             catch (Exception ex)
             {
-                File.AppendAllText("overtime_debug_log.txt", $"{DateTime.Now}: ERROR: {ex.Message}{Environment.NewLine}");
+                File.AppendAllText(overtimeLogPath, $"{DateTime.Now}: ERROR: {ex.Message}{Environment.NewLine}");
             }
         }
 
@@ -192,8 +226,9 @@ namespace ClockEnforcer
             {
                 string user = txtUsername.Text;
                 string pass = txtPassword.Text;
+                string systemUser = Environment.UserName;
 
-                if (logService.IsUserLockedOut(user))
+                if (logService.IsUserLockedOut(systemUser))
                 {
                     statusTextBox.Text = "Access Denied: Locked out.";
                     return;
@@ -213,7 +248,7 @@ namespace ClockEnforcer
             catch (Exception ex)
             {
                 statusTextBox.Text = "An error occurred during login. Please try again.";
-                File.AppendAllText("error_log.txt", $"{DateTime.Now}: {ex}{Environment.NewLine}");
+                File.AppendAllText(errorLogPath, $"{DateTime.Now}: {ex}{Environment.NewLine}");
             }
             finally
             {
@@ -227,27 +262,34 @@ namespace ClockEnforcer
 
         private async Task ProcessPunchAsync(string user, string pass)
         {
-            string resp = await punchService.PunchAsync();
+            string resp = await punchService.PunchAsync(user, pass);
             statusTextBox.Text = resp;
+            string systemUser = Environment.UserName;
 
-            if (resp.Contains("PUNCH_OUT"))
+            if (resp.Contains("PUNCH_OUT", StringComparison.OrdinalIgnoreCase))
             {
+                sessionManager.OnPunchOut(logService.HasCompletedShiftForToday(systemUser));
+                StopOvertimeMonitoring();
+                if (loginReenableTimer != null)
+                {
+                    loginReenableTimer.Stop();
+                    loginReenableTimer.Dispose();
+                    loginReenableTimer = null;
+                }
+
+                btnLogin.Enabled = true;
                 await Task.Delay(5000);
                 new PCLoginEnforcer().ForceUserLogOff();
             }
-            else if (resp.Contains("PUNCH_IN"))
+            else if (resp.Contains("PUNCH_IN", StringComparison.OrdinalIgnoreCase))
             {
-                loginTimer?.Stop();
-                loginTimer?.Dispose();
-                loginTimer = null;
+                sessionManager.OnPunchIn();
+                btnRequestOvertime.Enabled = logService.GetTodayLoginCount(systemUser) >= 2;
 
-                btnRequestOvertime.Enabled = logService.GetTodayLoginCount(user) >= 2;
+                StartOvertimeMonitoring();
 
-                overtimeAdded = false;
-                overtimeCheckTimer = new System.Windows.Forms.Timer { Interval = 30_000 };
-                overtimeCheckTimer.Tick += OvertimeCheckTimer_Tick;
-                overtimeCheckTimer.Start();
-
+                loginReenableTimer?.Stop();
+                loginReenableTimer?.Dispose();
                 loginReenableTimer = new System.Windows.Forms.Timer { Interval = 1_800_000 };
                 loginReenableTimer.Tick += (s, e) =>
                 {
@@ -270,18 +312,25 @@ namespace ClockEnforcer
             }
         }
 
-    }
+        private void StartOvertimeMonitoring()
+        {
+            overtimeAdded = false;
+            StopOvertimeMonitoring();
+            overtimeCheckTimer = new System.Windows.Forms.Timer { Interval = 30_000 };
+            overtimeCheckTimer.Tick += OvertimeCheckTimer_Tick;
+            overtimeCheckTimer.Start();
+        }
 
-    public class OvertimeTodayResponse
-    {
-        public int status { get; set; }
-        public string label { get; set; }
-        public OvertimeData data { get; set; }
-    }
+        private void StopOvertimeMonitoring()
+        {
+            if (overtimeCheckTimer != null)
+            {
+                overtimeCheckTimer.Stop();
+                overtimeCheckTimer.Tick -= OvertimeCheckTimer_Tick;
+                overtimeCheckTimer.Dispose();
+                overtimeCheckTimer = null;
+            }
+        }
 
-    public class OvertimeData
-    {
-        public bool accepted { get; set; }
-        public decimal hours { get; set; }
     }
 }

--- a/OvertimeRequestForm.cs
+++ b/OvertimeRequestForm.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using ClockEnforcer.Services;
 
 namespace ClockEnforcer
 {

--- a/OvertimeRequestService.cs
+++ b/OvertimeRequestService.cs
@@ -1,38 +1,77 @@
-﻿using System.Net.Http;
-using System.Net.Http.Headers;
+using System;
+using System.Net.Http;
 using System.Text;
 using System.Text.Json;
+using System.Threading.Tasks;
 
-public class OvertimeRequestService
+namespace ClockEnforcer.Services
 {
-    private readonly HttpClient _httpClient;
-
-    public OvertimeRequestService()
+    public class OvertimeRequestService
     {
-        _httpClient = new HttpClient();
+        private readonly HttpClient httpClient;
+        private const string BaseUrl = "https://clock.adrianas.com/backend/timeclock";
+
+        public OvertimeRequestService()
+        {
+            httpClient = new HttpClient();
+        }
+
+        public async Task<bool> SendOvertimeRequestAsync(string adUsername, string note, decimal hours)
+        {
+            var requestData = new
+            {
+                ad_username = adUsername,
+                reason = note,
+                overtime_hours = hours
+            };
+
+            var jsonContent = JsonSerializer.Serialize(requestData);
+            using var content = new StringContent(jsonContent, Encoding.UTF8, "application/json");
+
+            try
+            {
+                var response = await httpClient.PostAsync($"{BaseUrl}/overtime", content);
+                return response.IsSuccessStatusCode;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public async Task<OvertimeTodayResponse?> GetTodayOvertimeStatusAsync(string adUsername)
+        {
+            try
+            {
+                var response = await httpClient.GetAsync($"{BaseUrl}/overtime/today?ad_username={adUsername}");
+                if (!response.IsSuccessStatusCode)
+                {
+                    return null;
+                }
+
+                string json = await response.Content.ReadAsStringAsync();
+                return JsonSerializer.Deserialize<OvertimeTodayResponse>(json, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                });
+            }
+            catch
+            {
+                return null;
+            }
+        }
     }
 
-    public async Task<bool> SendOvertimeRequestAsync(string adUsername, string note, decimal hours)
+    public class OvertimeTodayResponse
     {
-        var requestData = new
-        {
-            ad_username = adUsername,
-            reason = note,
-            overtime_hours = hours
-        };
+        public int Status { get; set; }
+        public string Label { get; set; }
+        public OvertimeData Data { get; set; }
+    }
 
-        var jsonContent = JsonSerializer.Serialize(requestData);
-        var content = new StringContent(jsonContent, Encoding.UTF8, "application/json");
-
-        try
-        {
-            var response = await _httpClient.PostAsync("https://clock.adrianas.com/backend/timeclock/overtime", content);
-
-            return response.IsSuccessStatusCode;
-        }
-        catch
-        {
-            return false;
-        }
+    public class OvertimeData
+    {
+        public bool Accepted { get; set; }
+        public decimal Hours { get; set; }
     }
 }

--- a/PCLoginEnforcer.cs
+++ b/PCLoginEnforcer.cs
@@ -22,6 +22,12 @@ namespace ClockEnforcer
 
         public void EnforceLoginRestrictions(string username)
         {
+            if (logService.HasCompletedShiftForToday(username))
+            {
+                ForceUserLogOff();
+                return;
+            }
+
             int todayCount = logService.GetTodayLoginCount(username);
             if (todayCount % 2 != 0)
             {

--- a/PunchService.cs
+++ b/PunchService.cs
@@ -1,33 +1,33 @@
-﻿using System;
-using System.IO;
+using System;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
-using ClockEnforcer.Services; // Asegúrate de tener este namespace si está en otro proyecto
+using ClockEnforcer.Services;
 
-public class PunchService
+namespace ClockEnforcer.Services
 {
-    private readonly string punchUrl = "https://secure3.saashr.com/ta/rest/v1/webclock";
-    private readonly AuthService authService;
-    private readonly LogService logService = new LogService(); // ← Añadido
-
-    public PunchService(AuthService authService)
+    public class PunchService
     {
-        this.authService = authService;
-    }
+        private readonly string punchUrl = "https://secure3.saashr.com/ta/rest/v1/webclock";
+        private readonly AuthService authService;
+        private readonly LogService logService = new LogService();
 
-    public async Task<string> PunchAsync()
-    {
-        string systemUsername = Environment.UserName;
-
-        if (logService.HasExceededMaxLogins(systemUsername))
+        public PunchService(AuthService authService)
         {
-            return "Maximum number of logins reached for today. Cannot punch.";
+            this.authService = authService;
         }
 
-        using (HttpClient client = new HttpClient())
+        public async Task<string> PunchAsync(string clockinUsername = null, string password = null)
         {
+            string systemUsername = Environment.UserName;
+
+            if (logService.HasExceededMaxLogins(systemUsername))
+            {
+                return "Maximum number of logins reached for today. Cannot punch.";
+            }
+
+            using HttpClient client = new HttpClient();
             string token = authService.GetToken();
             if (string.IsNullOrEmpty(token))
             {
@@ -39,38 +39,32 @@ public class PunchService
             client.DefaultRequestHeaders.Add("User-Agent", "Thunder Client");
 
             var payload = new { action = "punch" };
-            var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+            using var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
 
             HttpResponseMessage response = await client.PostAsync(punchUrl, content);
             string jsonResponse = await response.Content.ReadAsStringAsync();
 
             if (response.IsSuccessStatusCode)
             {
-                using (JsonDocument doc = JsonDocument.Parse(jsonResponse))
+                using JsonDocument doc = JsonDocument.Parse(jsonResponse);
+                JsonElement root = doc.RootElement;
+
+                if (root.TryGetProperty("punch", out JsonElement punchElement) &&
+                    punchElement.TryGetProperty("type", out JsonElement typeElement))
                 {
-                    JsonElement root = doc.RootElement;
+                    string punchType = typeElement.GetString() ?? "UNKNOWN";
 
-                    if (root.TryGetProperty("punch", out JsonElement punchElement) &&
-                        punchElement.TryGetProperty("type", out JsonElement typeElement))
+                    if (punchType.Equals("PUNCH_OUT", StringComparison.OrdinalIgnoreCase))
                     {
-                        string punchType = typeElement.GetString() ?? "UNKNOWN";
+                        logService.LogClockOut(systemUsername);
+                        return $"Punch Successful: {punchType} YOU WILL BE LOGGED OUT IN 10 SECONDS";
+                    }
 
-                        if (punchType.Equals("PUNCH_OUT", StringComparison.OrdinalIgnoreCase))
-                        {
-                            logService.LogClockOut(systemUsername);
-                            return $"Punch Successful: {punchType} YOU WILL BE LOGGED OUT IN 10 SECONDS";
-                        } 
-                        else
-                        {
-                            logService.LogLogin(systemUsername);
-                            return $"Punch Successful: {punchType}";
-                        }
-                    }
-                    else
-                    {
-                        return $"Punch Not Successful: Invalid Punch Time Detected. {jsonResponse}";
-                    }
+                    logService.LogLogin(clockinUsername ?? systemUsername, password);
+                    return $"Punch Successful: {punchType}";
                 }
+
+                return $"Punch Not Successful: Invalid Punch Time Detected. {jsonResponse}";
             }
 
             return "Punch Failed!";

--- a/SessionContext.cs
+++ b/SessionContext.cs
@@ -1,0 +1,7 @@
+namespace ClockEnforcer
+{
+    internal static class SessionContext
+    {
+        public static SessionEnforcementManager SessionManager { get; set; }
+    }
+}

--- a/SessionEnforcementManager.cs
+++ b/SessionEnforcementManager.cs
@@ -1,0 +1,177 @@
+using System;
+using System.IO;
+using System.Threading;
+using ClockEnforcer.Services;
+
+namespace ClockEnforcer
+{
+    internal sealed class SessionEnforcementManager : IDisposable
+    {
+        private readonly TimeSpan preLoginGrace = TimeSpan.FromMinutes(2);
+        private readonly TimeSpan lunchWindow = TimeSpan.FromHours(5);
+        private readonly TimeSpan defaultShiftLength = TimeSpan.FromHours(8);
+        private readonly PCLoginEnforcer enforcer = new PCLoginEnforcer();
+        private readonly object gate = new object();
+        private readonly string debugLogPath;
+
+        private Timer preLoginTimer;
+        private Timer lunchTimer;
+        private Timer forcedLogoutTimer;
+        private DateTime? shiftStart;
+        private TimeSpan totalShiftLength;
+        private readonly string username;
+
+        public SessionEnforcementManager(string username)
+        {
+            this.username = username ?? throw new ArgumentNullException(nameof(username));
+            totalShiftLength = defaultShiftLength;
+            debugLogPath = Path.Combine(LogService.ApplicationFolder, "session_debug_log.txt");
+        }
+
+        public event Action<string> WarningIssued;
+
+        public void StartPreLoginCountdown()
+        {
+            lock (gate)
+            {
+                ResetShiftLocked();
+                RestartTimer(ref preLoginTimer, PreLoginExpired, preLoginGrace);
+            }
+        }
+
+        public void CancelPreLoginCountdown()
+        {
+            lock (gate)
+            {
+                CancelTimer(ref preLoginTimer);
+            }
+        }
+
+        public void OnPunchIn()
+        {
+            lock (gate)
+            {
+                CancelTimer(ref preLoginTimer);
+                StartLunchTimerLocked();
+                EnsureForcedLogoutTimerLocked(totalShiftLength);
+            }
+        }
+
+        public void OnPunchOut(bool isEndOfDay)
+        {
+            lock (gate)
+            {
+                CancelTimer(ref lunchTimer);
+                if (isEndOfDay)
+                {
+                    ResetShiftLocked();
+                }
+            }
+        }
+
+        public void StartForcedLogoutTimer(double totalHours)
+        {
+            lock (gate)
+            {
+                totalShiftLength = TimeSpan.FromHours(totalHours);
+                EnsureForcedLogoutTimerLocked(totalShiftLength);
+            }
+        }
+
+        private void EnsureForcedLogoutTimerLocked(TimeSpan shiftLength)
+        {
+            if (shiftStart == null || shiftStart.Value.Date < DateTime.Today)
+            {
+                shiftStart = DateTime.Now;
+            }
+
+            TimeSpan due = shiftStart.Value.Add(shiftLength) - DateTime.Now;
+            if (due < TimeSpan.Zero)
+            {
+                due = TimeSpan.Zero;
+            }
+
+            RestartTimer(ref forcedLogoutTimer, ForcedLogoutExpired, due);
+        }
+
+        private void StartLunchTimerLocked()
+        {
+            RestartTimer(ref lunchTimer, LunchExpired, lunchWindow);
+        }
+
+        private void PreLoginExpired(object state)
+        {
+            WarningIssued?.Invoke("You did not clock in within 2 minutes. Locking workstation.");
+            WriteDebug("Pre-login grace expired. Forcing logout.");
+            enforcer.ForceUserLogOff();
+        }
+
+        private void LunchExpired(object state)
+        {
+            WarningIssued?.Invoke("Lunch window exceeded. Forcing clock out for lunch.");
+            WriteDebug("Lunch timer expired. Forcing logout.");
+            enforcer.ForceUserLogOff();
+        }
+
+        private void ForcedLogoutExpired(object state)
+        {
+            WarningIssued?.Invoke("Shift limit reached. Enforcing final logout.");
+            WriteDebug("Forced shift timer expired. Forcing logout.");
+            enforcer.ForceUserLogOff();
+            lock (gate)
+            {
+                ResetShiftLocked();
+            }
+        }
+
+        private static void RestartTimer(ref Timer timer, TimerCallback callback, TimeSpan dueTime)
+        {
+            timer?.Dispose();
+            timer = new Timer(callback, null, dueTime, Timeout.InfiniteTimeSpan);
+        }
+
+        private static void CancelTimer(ref Timer timer)
+        {
+            timer?.Dispose();
+            timer = null;
+        }
+
+        private void ResetShiftLocked()
+        {
+            CancelTimer(ref forcedLogoutTimer);
+            CancelTimer(ref lunchTimer);
+            shiftStart = null;
+            totalShiftLength = defaultShiftLength;
+        }
+
+        private void ResetAllTimers()
+        {
+            lock (gate)
+            {
+                CancelTimer(ref preLoginTimer);
+                ResetShiftLocked();
+            }
+        }
+
+        private void WriteDebug(string message)
+        {
+            try
+            {
+                File.AppendAllText(debugLogPath, $"{DateTime.Now}: [{username}] {message}{Environment.NewLine}");
+            }
+            catch
+            {
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (gate)
+            {
+                CancelTimer(ref preLoginTimer);
+                CancelTimer(ref lunchTimer);
+                CancelTimer(ref forcedLogoutTimer);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable `SessionEnforcementManager` and supporting context to centralize the 2‑minute grace timer, 5‑hour lunch window, and 8‑hour shift enforcement logic
- refactor the login workflow to rely on the new manager, persist logs under the shared data folder, and monitor overtime approvals so approved requests extend the forced logoff timer
- improve the punch, log, overtime, and enforcement services so credentials are captured, completed shifts trigger immediate lockouts, and overtime polling is reusable across the UI

## Testing
- `dotnet build` *(fails: command not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d1f2f9a888328960a830174b0f95b)